### PR TITLE
Standard module paths and the Trireme default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@ JavaScript Engine
 =================
 
 The JavaScript Engine library (jse) provides an [Actor](http://en.wikipedia.org/wiki/Actor_model) based abstraction so that JavaScript code can be 
-executed in a browser-less fashion. In-jvm support is provided in the form of [Rhino](https://developer.mozilla.org/en/docs/Rhino)
-and native JavaScript performance is provided by using
+executed in a browser-less fashion. In-jvm support is provided in the form of [Trireme](https://github.com/apigee/trireme#trireme),
+a Node API for [Rhino](https://developer.mozilla.org/en/docs/Rhino). Standalone Rhino is also supported with a RhinoShell environment.
+Native JavaScript performance is provided by using
 [Common Node](http://olegp.github.io/common-node/),
 [node.js](http://nodejs.org/) and
 [PhantomJS](http://phantomjs.org/) (these latter 3 are required to be installed separately).
+
+While multiple engines are provided, plugin authors are encouraged to target the Node API. Doing so means that the
+engine options generally come down to Trireme and Node, depending on whether in-JVM or native support is required. Trireme
+is therefore provided as a default as there should be no JS coding differences between Trireme and Node, and Trireme
+requires no manual installation.
 
 Sample usage can be obtained by inspecting the js-engine-tester sub-project. There's a main class that
 illustrates essential interactions. Here is a snippet of it:
@@ -19,7 +25,7 @@ illustrates essential interactions. Here is a snippet of it:
       println(new String(result.output.toArray, "UTF-8"))
       ...
 
-An additional js-engine-sbt sub-project is provided that declares the a base for sbt plugins that use the engine.
+An additional sbt-js-engine sub-project is provided that declares a base for sbt plugins that use the engine.
 This sub-project has a separate release cycle to jse itself and could be spun off into its own repo at a later
 point in time e.g. if/when Maven/Gradle support is required. The main point here is that the core JavaScript engine
 library is not related to sbt at all and should be usable from other build tools.

--- a/sbt-js-engine/src/main/scala/com/typesafe/jse/sbt/JsEnginePlugin.scala
+++ b/sbt-js-engine/src/main/scala/com/typesafe/jse/sbt/JsEnginePlugin.scala
@@ -20,7 +20,7 @@ object JsEnginePlugin extends sbt.Plugin {
   import JsEngineKeys._
 
   def jsEngineSettings: Seq[Setting[_]] = Seq(
-    engineType := EngineType.Rhino,
+    engineType := EngineType.Trireme,
     parallelism := java.lang.Runtime.getRuntime.availableProcessors() + 1
   )
 

--- a/src/main/scala/com/typesafe/jse/Trireme.scala
+++ b/src/main/scala/com/typesafe/jse/Trireme.scala
@@ -16,7 +16,11 @@ import java.nio.charset.Charset
  * The <a href="https://github.com/apigee/trireme#trireme">Trireme</a> project provides this capability.
  * The actor is expected to be associated with a blocking dispatcher as its use of Jdk streams are blocking.
  */
-class Trireme(ioDispatcherId: String) extends Engine {
+class Trireme(
+               stdArgs: immutable.Seq[String],
+               stdModulePaths: immutable.Seq[String],
+               ioDispatcherId: String
+               ) extends Engine {
 
   // The main objective of this actor implementation is to establish actors for both the execution of
   // Trireme code (Trireme's execution is blocking), and actors for the source of stdio (which is also blocking).
@@ -50,8 +54,8 @@ class Trireme(ioDispatcherId: String) extends Engine {
 
         context.actorOf(TriremeShell.props(
           source,
-          args,
-          modulePaths,
+          stdArgs ++ args,
+          stdModulePaths ++ modulePaths,
           stdinIs, stdoutOs, stderrOs
         ), "trireme-shell") ! TriremeShell.Execute
 
@@ -91,8 +95,12 @@ object Trireme {
   /**
    * Give me a Trireme props.
    */
-  def props(ioDispatcherId: String = "blocking-process-io-dispatcher"): Props = {
-    Props(classOf[Trireme], ioDispatcherId)
+  def props(
+             stdArgs: immutable.Seq[String] = Nil,
+             stdModulePaths: immutable.Seq[String] = Nil,
+             ioDispatcherId: String = "blocking-process-io-dispatcher"
+             ): Props = {
+    Props(classOf[Trireme], stdArgs, stdModulePaths, ioDispatcherId)
       .withDispatcher(ioDispatcherId)
   }
 


### PR DESCRIPTION
Commits us to the Node API strategy by making Trireme the default. This is a good thing! :-)

In addition the notion of a standard module path is introduced for Node style engines. This reduces the need to pass data around.
