### PR TITLE
Changes dependency on sbt-web from M1 back to SNAPSHOT

### DIFF
--- a/sbt-js-engine/build.sbt
+++ b/sbt-js-engine/build.sbt
@@ -15,10 +15,10 @@ resolvers ++= Seq(
     )
 
 libraryDependencies ++= Seq(
-  "com.typesafe" %% "jse" % "1.0.0-M1"
+  "com.typesafe" %% "jse" % "1.0.0-SNAPSHOT"
 )
 
-addSbtPlugin("com.typesafe" % "sbt-web" % "1.0.0-M1")
+addSbtPlugin("com.typesafe" % "sbt-web" % "1.0.0-SNAPSHOT")
 
 publishMavenStyle := false
 


### PR DESCRIPTION
Would like to get the fix for https://github.com/typesafehub/sbt-web/pull/8 pulled into the other snapshots in the sbt-web ecosystem. Seems like the M1 back to SNAPSHOT was missed here.
