### PR TITLE
Supply target folders to shell scripts and ensure that returned path mappings are correct

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.2-M2

--- a/sbt-js-engine/src/test/scala/com/typesafe/sbt/jse/SbtJsTaskPluginSpec.scala
+++ b/sbt-js-engine/src/test/scala/com/typesafe/sbt/jse/SbtJsTaskPluginSpec.scala
@@ -34,7 +34,7 @@ class SbtJsTaskPluginSpec extends Specification with NoTimeConversions {
                           ],
                           "filesWritten": []
                       },
-                      "source": "src/main/assets/js/a.js"
+                      "source": ["src/main/assets/js/a.js", "/js/a.js"]
                   }
               ]
           }
@@ -53,7 +53,7 @@ class SbtJsTaskPluginSpec extends Specification with NoTimeConversions {
       val opSuccess = problemResultsPair.results(0).result.asInstanceOf[OpSuccess]
       opSuccess.filesRead.size must_== 1
       opSuccess.filesWritten.size must_== 0
-      problemResultsPair.results(0).source must_== new File("src/main/assets/js/a.js")
+      problemResultsPair.results(0).source must_== new File("src/main/assets/js/a.js") -> "/js/a.js"
     }
   }
 


### PR DESCRIPTION
The main motivation for this change is to provide shell scripts with a means to obtain a target folder for writing to.

In addition source file plugins will now always return a complete Seq[PathMapping] structure and not just those paths that have been operated on incrementally. The new sbt 0.13.2 functionality of .previous has be utilised in this.

The marshalling of PathMapping values from shell scripts is also now done properly.

Upgraded to sbt 0.13.2-M2 so that the new .previous method can be used.

Some of the setting declaration was also simplified.
