### PR TITLE
Timeout with a large set of files processed via Trireme

### DIFF
--- a/js-engine-tester/src/main/scala/com/typesafe/jse/tester/Main.scala
+++ b/js-engine-tester/src/main/scala/com/typesafe/jse/tester/Main.scala
@@ -21,7 +21,7 @@ object Main {
       System.exit(1)
     }
 
-    val engine = system.actorOf(Node.props(Some(new File("/usr/local/bin/node"))), "engine")
+    val engine = system.actorOf(Node.props(), "engine")
     val f = new File(Main.getClass.getResource("test.js").toURI)
     for (
       result <- (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]

--- a/src/main/scala/com/typesafe/jse/Engine.scala
+++ b/src/main/scala/com/typesafe/jse/Engine.scala
@@ -57,11 +57,11 @@ abstract class Engine(stdArgs: immutable.Seq[String], stdEnvironment: Map[String
     }
 
     {
-      case bytes: ByteString => handleStdioBytes(sender, bytes)
+      case bytes: ByteString => handleStdioBytes(sender(), bytes)
       case exitValue: Int =>
         if (exitValue != timeoutExitValue) {
           context.become {
-            case bytes: ByteString => handleStdioBytes(sender, bytes)
+            case bytes: ByteString => handleStdioBytes(sender(), bytes)
             case Terminated(`stdinSink` | `stdoutSource` | `stderrSource`) => {
               openStreams -= 1
               if (openStreams == 0) {

--- a/src/main/scala/com/typesafe/jse/LocalEngine.scala
+++ b/src/main/scala/com/typesafe/jse/LocalEngine.scala
@@ -18,7 +18,7 @@ class LocalEngine(stdArgs: immutable.Seq[String], stdEnvironment: Map[String, St
 
   def receive = {
     case ExecuteJs(f, args, timeout, timeoutExitValue, environment) =>
-      val requester = sender
+      val requester = sender()
 
       context.actorOf(BlockingProcess.props(
         (stdArgs :+ f.getCanonicalPath) ++ args,

--- a/src/main/scala/com/typesafe/jse/Rhino.scala
+++ b/src/main/scala/com/typesafe/jse/Rhino.scala
@@ -7,9 +7,11 @@ import org.mozilla.javascript._
 import scala.concurrent.blocking
 import java.io._
 import akka.contrib.process.StreamEvents.Ack
-import akka.contrib.process.{Sink, Source}
+import akka.contrib.process._
 import scala.collection.immutable
+import scala.concurrent.duration._
 import com.typesafe.jse.Engine.ExecuteJs
+import scala.util.Try
 
 /**
  * Declares an in-JVM Rhino based JavaScript engine. The actor is expected to be
@@ -27,25 +29,20 @@ class Rhino(
   // Rhino code (Rhino's execution is blocking), and actors for the source of stdio (which is also blocking).
   // This actor is then a conduit of the IO as a result of execution.
 
-  val stdoutOs = new PipedOutputStream()
-  val stderrOs = new PipedOutputStream()
-
-  val stdoutIs = new PipedInputStream(stdoutOs)
-  val stderrIs = new PipedInputStream(stderrOs)
+  val StdioTimeout = 30.seconds
 
   def receive = {
     case ExecuteJs(source, args, timeout, timeoutExitValue, environment) =>
-      val requester = sender
+      val requester = sender()
 
-      // Create an input stream and close it immediately as it isn't going to be used.
-      val stdinOs = new PipedOutputStream()
-      val stdinIs = new PipedInputStream(stdinOs)
+      val stdinSink = context.actorOf(BufferingSink.props(ioDispatcherId = ioDispatcherId), "stdin")
+      val stdinIs = new SourceStream(stdinSink, StdioTimeout)
+      val stdoutSource = context.actorOf(ForwardingSource.props(self, ioDispatcherId = ioDispatcherId), "stdout")
+      val stdoutOs = new SinkStream(stdoutSource, StdioTimeout)
+      val stderrSource = context.actorOf(ForwardingSource.props(self, ioDispatcherId = ioDispatcherId), "stderr")
+      val stderrOs = new SinkStream(stderrSource, StdioTimeout)
 
       try {
-        val stdinSink = context.actorOf(Sink.props(stdinOs, ioDispatcherId = ioDispatcherId), "stdin")
-        val stdoutSource = context.actorOf(Source.props(stdoutIs, self, ioDispatcherId = ioDispatcherId), "stdout")
-        val stderrSource = context.actorOf(Source.props(stderrIs, self, ioDispatcherId = ioDispatcherId), "stderr")
-
         context.become(engineIOHandler(
           stdinSink, stdoutSource, stderrSource,
           requester,
@@ -61,35 +58,11 @@ class Rhino(
           rhinoShellDispatcherId
         ), "rhino-shell") ! RhinoShell.Execute
 
-        // We don't need an input stream so close it out straight away.
-        stdinSink ! PoisonPill
-
       } finally {
-        blocking {
-          closeSafely(stdinIs)
-          closeSafely(stdinOs)
-        }
+        // We don't need stdin
+        blocking(Try(stdinIs.close()))
       }
   }
-
-  def closeSafely(closable: Closeable): Unit = {
-    try {
-      closable.close()
-    } catch {
-      case _: Exception =>
-    }
-  }
-
-  override def postStop() = {
-    // Be paranoid and ensure that all resources are cleared up.
-    blocking {
-      closeSafely(stderrIs)
-      closeSafely(stdoutIs)
-      closeSafely(stderrOs)
-      closeSafely(stdoutOs)
-    }
-  }
-
 }
 
 object Rhino {
@@ -158,7 +131,7 @@ private[jse] class RhinoShell(
         }
       }
 
-      sender ! exitCode
+      sender() ! exitCode
   }
 
 }

--- a/src/test/scala/com/typesafe/jse/RhinoSpec.scala
+++ b/src/test/scala/com/typesafe/jse/RhinoSpec.scala
@@ -11,6 +11,7 @@ import org.specs2.time.NoTimeConversions
 import akka.util.Timeout
 import akka.actor.ActorSystem
 import scala.concurrent.Await
+import java.util.concurrent.TimeUnit
 
 @RunWith(classOf[JUnitRunner])
 class RhinoSpec extends Specification with NoTimeConversions {
@@ -20,7 +21,7 @@ class RhinoSpec extends Specification with NoTimeConversions {
       val system = ActorSystem()
       val engine = system.actorOf(Rhino.props())
       val f = new File(classOf[RhinoSpec].getResource("test-rhino.js").toURI)
-      implicit val timeout = Timeout(5000L)
+      implicit val timeout = Timeout(5000L, TimeUnit.MILLISECONDS)
 
       val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]
       val result = Await.result(futureResult, timeout.duration)

--- a/src/test/scala/com/typesafe/jse/TriremeSpec.scala
+++ b/src/test/scala/com/typesafe/jse/TriremeSpec.scala
@@ -9,23 +9,44 @@ import scala.collection.immutable
 import akka.pattern.ask
 import org.specs2.time.NoTimeConversions
 import akka.util.Timeout
-import akka.actor.ActorSystem
+import akka.actor.{ActorRef, ActorSystem}
 import scala.concurrent.Await
+import java.util.concurrent.TimeUnit
 
 @RunWith(classOf[JUnitRunner])
 class TriremeSpec extends Specification with NoTimeConversions {
 
+  def withEngine[T](block: ActorRef => T): T = {
+    val system = ActorSystem()
+    val engine = system.actorOf(Trireme.props())
+    block(engine)
+  }
+
   "The Trireme engine" should {
     "execute some javascript by passing in a string arg and comparing its return value" in {
-      val system = ActorSystem()
-      val engine = system.actorOf(Trireme.props())
-      val f = new File(classOf[TriremeSpec].getResource("test-node.js").toURI)
-      implicit val timeout = Timeout(5000L)
+      withEngine {
+        engine =>
+          val f = new File(classOf[TriremeSpec].getResource("test-node.js").toURI)
+          implicit val timeout = Timeout(5000L, TimeUnit.MILLISECONDS)
 
-      val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]
-      val result = Await.result(futureResult, timeout.duration)
-      new String(result.output.toArray, "UTF-8").trim must_== "999"
+          val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]
+          val result = Await.result(futureResult, timeout.duration)
+          new String(result.output.toArray, "UTF-8").trim must_== "999"
+          new String(result.error.toArray, "UTF-8").trim must_== ""
+      }
+    }
 
+    "execute some javascript by passing in a string arg and comparing its return value expecting an error" in {
+      withEngine {
+        engine =>
+          val f = new File(classOf[TriremeSpec].getResource("test-rhino.js").toURI)
+          implicit val timeout = Timeout(5000L, TimeUnit.MILLISECONDS)
+
+          val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]
+          val result = Await.result(futureResult, timeout.duration)
+          new String(result.output.toArray, "UTF-8").trim must_== ""
+          new String(result.error.toArray, "UTF-8").trim must startWith("""ReferenceError: "print" is not defined""")
+      }
     }
   }
 


### PR DESCRIPTION
When we tried invoking the sbt-less plugin on the Activator project, about 50 LESS files were attempted to be processed. The build failed with an actor ask timeout.

After analysing stack dumps and profiling via YourKit I discovered that both ends of the PipedInput/OutputStreams appeared to be waiting for each other. It turns out that the PipedInput/OutputStream classes are unsuitable for situations where thread pools are used and the thread that is used to write output is unpredictable.

I have now eliminated the JDK PipedInput/OutputStream usage by replacing with enhanced Source and Sink types along with a new SourceStream and a SinkStream type.
