### PR TITLE
Changed Rhino implementation to evaluate scripts in a context instead of...

### DIFF
--- a/js-engine-tester/src/main/resources/application.conf
+++ b/js-engine-tester/src/main/resources/application.conf
@@ -1,13 +1,3 @@
-rhino-shell-dispatcher {
-  type = Dispatcher
-  executor = "thread-pool-executor"
-  thread-pool-executor {
-    core-pool-size-min = 1
-    core-pool-size-factor = 1.0
-    core-pool-size-max = 1
-  }
-}
-
 blocking-process-io-dispatcher {
   type = Dispatcher
   executor = "thread-pool-executor"

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,13 +1,3 @@
-rhino-shell-dispatcher {
-  type = Dispatcher
-  executor = "thread-pool-executor"
-  thread-pool-executor {
-    core-pool-size-min = 1
-    core-pool-size-factor = 1.0
-    core-pool-size-max = 1
-  }
-}
-
 blocking-process-io-dispatcher {
   type = Dispatcher
   executor = "thread-pool-executor"

--- a/src/test/resources/com/typesafe/jse/hello.js
+++ b/src/test/resources/com/typesafe/jse/hello.js
@@ -1,0 +1,5 @@
+// A simple CommonJS module
+exports.sayHello = function (you) {
+  return "Hello " + you;
+};
+

--- a/src/test/resources/com/typesafe/jse/test-rhino.js
+++ b/src/test/resources/com/typesafe/jse/test-rhino.js
@@ -1,1 +1,7 @@
-print(arguments[0]);
+// Check that we have Rhino shell methods in scope
+readFile("src/test/resources/com/typesafe/jse/hello.js");
+
+// Check CommonJS support
+var sayHello = require("hello").sayHello;
+
+print(sayHello(arguments[0]));

--- a/src/test/scala/com/typesafe/jse/RhinoSpec.scala
+++ b/src/test/scala/com/typesafe/jse/RhinoSpec.scala
@@ -7,25 +7,55 @@ import com.typesafe.jse.Engine.JsExecutionResult
 import java.io.File
 import scala.collection.immutable
 import akka.pattern.ask
-import org.specs2.time.NoTimeConversions
 import akka.util.Timeout
-import akka.actor.ActorSystem
+import akka.actor.{ActorRef, ActorSystem}
 import scala.concurrent.Await
 import java.util.concurrent.TimeUnit
 
 @RunWith(classOf[JUnitRunner])
-class RhinoSpec extends Specification with NoTimeConversions {
+class RhinoSpec extends Specification {
+
+  //sequential
+
+  def withEngine[T](block: ActorRef => T): T = {
+    val system = ActorSystem()
+    val engine = system.actorOf(Rhino.props(), "engine")
+    try {
+      block(engine)
+    } finally {
+      system.shutdown()
+      system.awaitTermination()
+    }
+  }
 
   "The Rhino engine" should {
-    "execute some javascript by passing in a string arg and comparing its return value" in {
-      val system = ActorSystem()
-      val engine = system.actorOf(Rhino.props())
-      val f = new File(classOf[RhinoSpec].getResource("test-rhino.js").toURI)
-      implicit val timeout = Timeout(5000L, TimeUnit.MILLISECONDS)
 
-      val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]
-      val result = Await.result(futureResult, timeout.duration)
-      new String(result.output.toArray, "UTF-8").trim must_== "999"
+    "execute some javascript by passing in a string arg and comparing its return value" in {
+      withEngine {
+        engine =>
+          val f = new File(classOf[RhinoSpec].getResource("test-rhino.js").toURI)
+          implicit val timeout = Timeout(5000L, TimeUnit.MILLISECONDS)
+
+          val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]
+          val result = Await.result(futureResult, timeout.duration)
+
+          new String(result.error.toArray, "UTF-8").trim mustEqual ""
+          new String(result.output.toArray, "UTF-8").trim mustEqual "Hello 999"
+      }
+    }
+
+    "execute some javascript by passing in a string arg and comparing its return value expecting an error" in {
+      withEngine {
+        engine =>
+          val f = new File(classOf[RhinoSpec].getResource("test-node.js").toURI)
+          implicit val timeout = Timeout(5000L, TimeUnit.MILLISECONDS)
+
+          val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("888"), timeout.duration)).mapTo[JsExecutionResult]
+          val result = Await.result(futureResult, timeout.duration)
+
+          new String(result.output.toArray, "UTF-8").trim mustEqual ""
+          new String(result.error.toArray, "UTF-8").trim must contain("""Error: Module "console" not found""")
+      }
 
     }
   }

--- a/src/test/scala/com/typesafe/jse/TriremeSpec.scala
+++ b/src/test/scala/com/typesafe/jse/TriremeSpec.scala
@@ -45,7 +45,7 @@ class TriremeSpec extends Specification with NoTimeConversions {
           val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]
           val result = Await.result(futureResult, timeout.duration)
           new String(result.output.toArray, "UTF-8").trim must_== ""
-          new String(result.error.toArray, "UTF-8").trim must startWith("""ReferenceError: "print" is not defined""")
+          new String(result.error.toArray, "UTF-8").trim must startWith("""ReferenceError: "readFile" is not defined""")
       }
     }
   }


### PR DESCRIPTION
... the Rhino shell (which scope is mutated on each eval call!). RhinoShell has been renamed to RhinoExecutor as a result. Also fixed exception catching with Rhino engine (there was no test for this) and improved RhinoSpec to test for CommonJS support.

Fixes #20 and #21.

(I signed the Typesafe CLA)
