### PR TITLE
Added an Engine implementation based on the javax.script API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,3 +33,5 @@ lazy val root = project in file(".")
 
 lazy val `js-engine-tester` = project.dependsOn(root)
 
+// Somehow required to get a js engine in tests (https://github.com/sbt/sbt/issues/1214)
+fork in Test := true

--- a/src/main/scala/com/typesafe/jse/JavaxEngine.scala
+++ b/src/main/scala/com/typesafe/jse/JavaxEngine.scala
@@ -1,0 +1,143 @@
+package com.typesafe.jse
+
+import akka.actor._
+import akka.contrib.process.StreamEvents.Ack
+import akka.contrib.process._
+import java.io._
+import javax.script._
+import scala.collection.immutable
+import scala.concurrent.blocking
+import scala.concurrent.duration._
+import scala.util.Try
+
+import com.typesafe.jse.Engine.ExecuteJs
+
+/**
+ * Declares an in-JVM JavaScript engine. The actor is expected to be associated with a blocking dispatcher as the
+ * javax.script API is synchronous.
+ */
+class JavaxEngine(
+    stdArgs: immutable.Seq[String],
+    ioDispatcherId: String,
+    engineName: String
+  ) extends Engine(stdArgs, Map.empty) {
+
+  val StdioTimeout = 30.seconds
+
+  def receive = {
+    case ExecuteJs(source, args, timeout, timeoutExitValue, environment) =>
+      val requester = sender()
+
+      val stdinSink = context.actorOf(BufferingSink.props(ioDispatcherId = ioDispatcherId), "stdin")
+      val stdinIs = new SourceStream(stdinSink, StdioTimeout)
+      val stdoutSource = context.actorOf(ForwardingSource.props(self, ioDispatcherId = ioDispatcherId), "stdout")
+      val stdoutOs = new SinkStream(stdoutSource, StdioTimeout)
+      val stderrSource = context.actorOf(ForwardingSource.props(self, ioDispatcherId = ioDispatcherId), "stderr")
+      val stderrOs = new SinkStream(stderrSource, StdioTimeout)
+
+      try {
+        context.become(engineIOHandler(
+          stdinSink, stdoutSource, stderrSource,
+          requester,
+          Ack,
+          timeout, timeoutExitValue
+        ))
+
+        context.actorOf(JavaxEngineShell.props(
+          source.getCanonicalFile,
+          stdArgs ++ args,
+          stdinIs, stdoutOs, stderrOs,
+          engineName
+        ), "javax-engine-shell") ! JavaxEngineShell.Execute
+
+      } finally {
+        // We don't need stdin
+        blocking(Try(stdinIs.close()))
+      }
+  }
+}
+
+object JavaxEngine {
+
+  /**
+   * Creates the Props of a JavaxEngine
+   *
+   * @param stdArgs
+   * @param ioDispatcherId
+   * @param engineName The name of the engine to load. Defaults to "js".
+   * @return
+   */
+  def props(
+      stdArgs: immutable.Seq[String] = Nil,
+      ioDispatcherId: String = "blocking-process-io-dispatcher",
+      engineName: String = "js") =
+    Props(new JavaxEngine(stdArgs, ioDispatcherId, engineName)).withDispatcher(ioDispatcherId)
+
+}
+
+private[jse] class JavaxEngineShell(
+    script: File,
+    args: immutable.Seq[String],
+    stdinIs: InputStream,
+    stdoutOs: OutputStream,
+    stderrOs: OutputStream,
+    engineName: String
+  ) extends Actor with ActorLogging {
+
+  import JavaxEngineShell._
+
+  val engine = new ScriptEngineManager().getEngineByName(engineName)
+
+  if (engine == null) throw new Exception("Javascript engine not found")
+
+  def receive = {
+
+    case Execute =>
+
+      val scriptReader = new FileReader(script)
+
+      val reader = new InputStreamReader(stdinIs)
+      val writer = new PrintWriter(stdoutOs, true)
+      val errorWriter = new PrintWriter(stderrOs, true)
+
+      val context = {
+        val c = new SimpleScriptContext()
+        c.setReader(reader)
+        c.setWriter(writer)
+        c.setErrorWriter(errorWriter)
+        c.setAttribute("arguments", args.toArray, ScriptContext.ENGINE_SCOPE)
+        c.setAttribute(ScriptEngine.FILENAME, script.getName, ScriptContext.ENGINE_SCOPE)
+        c
+      }
+
+      try {
+        blocking(engine.eval(scriptReader, context))
+        sender() ! 0
+      } catch {
+        case e: ScriptException =>
+          e.printStackTrace(new PrintStream(stderrOs))
+          sender() ! 1
+      } finally {
+        // Will close the underlying stdoutOs and stderrOs
+        Try(writer.close())
+        Try(errorWriter.close())
+      }
+
+  }
+
+}
+
+private[jse] object JavaxEngineShell {
+
+  def props(
+      source: File,
+      args: immutable.Seq[String],
+      stdinIs: InputStream,
+      stdoutOs: OutputStream,
+      stderrOs: OutputStream,
+      engineName: String) =
+    Props(new JavaxEngineShell(source, args, stdinIs, stdoutOs, stderrOs, engineName))
+
+  case object Execute
+
+}

--- a/src/test/resources/com/typesafe/jse/test-javax.js
+++ b/src/test/resources/com/typesafe/jse/test-javax.js
@@ -1,0 +1,1 @@
+print(arguments[0]);

--- a/src/test/scala/com/typesafe/jse/JavaxEngineSpec.scala
+++ b/src/test/scala/com/typesafe/jse/JavaxEngineSpec.scala
@@ -1,0 +1,57 @@
+package com.typesafe.jse
+
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import org.specs2.mutable.Specification
+import com.typesafe.jse.Engine.JsExecutionResult
+import java.io.File
+import scala.collection.immutable
+import akka.pattern.ask
+import org.specs2.time.NoTimeConversions
+import akka.util.Timeout
+import akka.actor.{ActorRef, ActorSystem}
+import scala.concurrent.Await
+import java.util.concurrent.TimeUnit
+
+@RunWith(classOf[JUnitRunner])
+class JavaxEngineSpec extends Specification {
+
+  def withEngine[T](block: ActorRef => T): T = {
+    val system = ActorSystem()
+    val engine = system.actorOf(JavaxEngine.props(engineName = "js"))
+    try block(engine) finally {
+      system.shutdown()
+      system.awaitTermination()
+    }
+  }
+
+  "A JavaxEngine" should {
+
+    "execute some javascript by passing in a string arg and comparing its return value" in {
+      withEngine {
+        engine =>
+          val f = new File(classOf[JavaxEngineSpec].getResource("test-javax.js").toURI)
+          implicit val timeout = Timeout(5000L, TimeUnit.MILLISECONDS)
+
+          val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]
+          val result = Await.result(futureResult, timeout.duration)
+          new String(result.error.toArray, "UTF-8").trim must_== ""
+          new String(result.output.toArray, "UTF-8").trim must_== "999"
+      }
+    }
+
+    "execute some javascript by passing in a string arg and comparing its return value expecting an error" in {
+      withEngine {
+        engine =>
+          val f = new File(classOf[JavaxEngineSpec].getResource("test-node.js").toURI)
+          implicit val timeout = Timeout(5000L, TimeUnit.MILLISECONDS)
+
+          val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]
+          val result = Await.result(futureResult, timeout.duration)
+          new String(result.output.toArray, "UTF-8").trim must_== ""
+          new String(result.error.toArray, "UTF-8").trim must contain("""ReferenceError: "require" is not defined""")
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Closes #24.

Works both under jdk7 (Rhino based) and jdk8 (Nashorn based).
