### PR TITLE
Fixed trireme resource leaks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val `js-engine-tester` = project.dependsOn(root)
 
 // Somehow required to get a js engine in tests (https://github.com/sbt/sbt/issues/1214)
 fork in Test := true
+parallelExecution in Test := false
 
 // Publish settings
 publishTo := {

--- a/src/test/scala/com/typesafe/jse/TriremeSpec.scala
+++ b/src/test/scala/com/typesafe/jse/TriremeSpec.scala
@@ -11,11 +11,20 @@ import akka.actor.{ActorRef, ActorSystem}
 import scala.concurrent.Await
 import java.util.concurrent.TimeUnit
 
-class TriremeSpec extends Specification with NoTimeConversions {
+class TriremeSpec extends Specification {
 
-  def withEngine[T](block: ActorRef => T): T = {
+  sequential
+
+  def withActorSystem[T](block: ActorSystem => T): T = {
     val system = ActorSystem()
-    val engine = system.actorOf(Trireme.props())
+    try block(system) finally {
+      system.shutdown()
+      system.awaitTermination()
+    }
+  }
+
+  def withEngine[T](block: ActorRef => T): T = withActorSystem { system =>
+    val engine = system.actorOf(Trireme.props(), "trireme-spec")
     block(engine)
   }
 
@@ -43,6 +52,50 @@ class TriremeSpec extends Specification with NoTimeConversions {
           val result = Await.result(futureResult, timeout.duration)
           new String(result.output.toArray, "UTF-8").trim must_== ""
           new String(result.error.toArray, "UTF-8").trim must startWith("""ReferenceError: "readFile" is not defined""")
+      }
+    }
+
+    def runSimpleTest(system: ActorSystem) = {
+      implicit val timeout = Timeout(5000L, TimeUnit.MILLISECONDS)
+      val f = new File(classOf[TriremeSpec].getResource("test-node.js").toURI)
+      val engine = system.actorOf(Trireme.props(), "not-leak-threads-test")
+      val futureResult = (engine ? Engine.ExecuteJs(f, immutable.Seq("999"), timeout.duration)).mapTo[JsExecutionResult]
+      val result = Await.result(futureResult, timeout.duration)
+      new String(result.output.toArray, "UTF-8").trim must_== "999"
+      new String(result.error.toArray, "UTF-8").trim must_== ""
+    }
+
+    "not leak threads" in withActorSystem { system =>
+      // this test assumes that there are no other trireme tests running concurrently, if there are, the trireme thread
+      // count will be non 0
+      runSimpleTest(system)
+
+      import scala.collection.JavaConverters._
+      val triremeThreadCount = Thread.getAllStackTraces.keySet.asScala
+        .count(_.getName.contains("Trireme"))
+
+      triremeThreadCount must_== 0
+      ok
+    }
+
+
+    "not leak file descriptors" in withActorSystem { system =>
+      import java.lang.management._
+      val os = ManagementFactory.getOperatingSystemMXBean
+      // To get the open file descriptor count, you need to use non portable APIs, so use reflection
+      try {
+        val method = os.getClass.getMethod("getOpenFileDescriptorCount")
+        // method is public native, needs to be set accessible to be invoked using reflection
+        method.setAccessible(true)
+        def getCount = method.invoke(os).asInstanceOf[Long]
+
+        val openFds = getCount
+        runSimpleTest(system)
+        getCount must_== openFds
+      } catch {
+        case nse: NoSuchMethodException =>
+          println("Skipping file descriptor leak test because OS mbean doesn't have getOpenFileDescriptorCount")
+          ok
       }
     }
   }


### PR DESCRIPTION
* Fixed thread leak by configuring Trireme to use the blocking
  disptacher
* Explicitly shutdown the script engine thread to clean up resources
  faster
* Fixed file descriptor leak by shutting down the script, which creates
  an nio selector that needs to be shut down