### PR TITLE
More verbose error message in test

### DIFF
--- a/src/test/scala/com/typesafe/jse/TriremeSpec.scala
+++ b/src/test/scala/com/typesafe/jse/TriremeSpec.scala
@@ -70,11 +70,13 @@ class TriremeSpec extends Specification {
       // count will be non 0
       runSimpleTest(system)
 
-      import scala.collection.JavaConverters._
-      val triremeThreadCount = Thread.getAllStackTraces.keySet.asScala
-        .count(_.getName.contains("Trireme"))
+      Thread.sleep(1)
 
-      triremeThreadCount must_== 0
+      import scala.collection.JavaConverters._
+      val triremeThreads = Thread.getAllStackTraces.keySet.asScala
+        .filter(_.getName.contains("Trireme"))
+
+      ("trireme threads: " + triremeThreads) <==> (triremeThreads.size === 0)
       ok
     }
 


### PR DESCRIPTION
Expanding error message per @jroper's suggestion

Will hopefully help debug https://github.com/typesafehub/js-engine/issues/50. Shows name of offending thread is "Trireme Script Thread"